### PR TITLE
Fix typo in Flutter to iOS reuse duration parameter name

### DIFF
--- a/macos/Classes/BiometricStorageImpl.swift
+++ b/macos/Classes/BiometricStorageImpl.swift
@@ -14,7 +14,7 @@ struct StorageMethodCall {
 
 class InitOptions {
   init(params: [String: Any]) {
-    darwinTouchIDAuthenticationAllowableReuseDuration = params["drawinTouchIDAuthenticationAllowableReuseDurationSeconds"] as? Int
+    darwinTouchIDAuthenticationAllowableReuseDuration = params["darwinTouchIDAuthenticationAllowableReuseDurationSeconds"] as? Int
     darwinTouchIDAuthenticationForceReuseContextDuration = params["darwinTouchIDAuthenticationForceReuseContextDurationSeconds"] as? Int
     authenticationRequired = params["authenticationRequired"] as? Bool
     darwinBiometricOnly = params["darwinBiometricOnly"] as? Bool


### PR DESCRIPTION
The name of the parameter `darwinTouchIDAuthenticationAllowableReuseDurationSeconds on Flutter and Swift sides did not match, leading to the parameter to be ignored.